### PR TITLE
Add timeout paremeter to destroy-pipeline action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (default
 
 Set to `true` to destroy the persistent volumes created by the development environment (defaults to `false`).
 
+### `timeout`
+
+Timeout duration for the pipeline destroy operation. Values should contain a corresponding time unit e.g. 1s, 2m, 3h. If not specified it will use 5m.
+
 # Example usage
 
 This example runs the login action, activates a namespace, and triggers the Okteto pipeline and deletes it

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   dependencies:
     description: "Force destroy of repositories in the 'dependencies' section"
     required: false
+  timeout:
+    description: "Timeout duration in Golang format (e.g., '5m' for 5 minutes, '1h' for 1 hour)"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -26,6 +29,7 @@ runs:
     - ${{ inputs.log-level }}
     - ${{ inputs.destroy-volumes }}
     - ${{ inputs.dependencies }}
+    - ${{ inputs.timeout }}
 branding:
   color: 'green'
   icon: 'settings'

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "Force destroy of repositories in the 'dependencies' section"
     required: false
   timeout:
-    description: "Timeout duration in Golang format (e.g., '5m' for 5 minutes, '1h' for 1 hour)"
+    description: "Timeout duration for the pipeline destroy operation. Values should contain a corresponding time unit e.g. 1s, 2m, 3h. If not specified it will use 5m."
     required: false
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ namespace=$2
 log_level=$3
 destroy_volumes=$4
 dependencies=$5
+timeout=$6
 
 params=""
 if [ ! -z $namespace ]; then
@@ -38,6 +39,10 @@ if [ "$dependencies" = "false" ]; then
   params="${params} --dependencies=false"
 elif [ "$dependencies" = "true" ]; then
   params="${params} --dependencies"
+fi
+
+if [ ! -z "$timeout" ]; then
+  params="${params} --timeout=${timeout}"
 fi
 
 echo running: okteto pipeline destroy --name "${name}" ${params} --wait


### PR DESCRIPTION
CLI already supports timeout flag, but the action doesn't support it, so there is no way of configuring it. This PR adds the support for that flag